### PR TITLE
refactor: extract advisor configuration to dedicated service layer

### DIFF
--- a/src/main/java/com/moguyn/deepdesk/advisor/AdvisorService.java
+++ b/src/main/java/com/moguyn/deepdesk/advisor/AdvisorService.java
@@ -1,0 +1,22 @@
+package com.moguyn.deepdesk.advisor;
+
+import java.util.List;
+
+import org.springframework.ai.chat.client.advisor.api.Advisor;
+
+import com.moguyn.deepdesk.config.CoreSettings;
+
+/**
+ * Service responsible for determining which advisors should be enabled based on
+ * application configuration.
+ */
+public interface AdvisorService {
+
+    /**
+     * Returns a list of enabled advisors based on application settings.
+     *
+     * @param settings Application core settings
+     * @return List of enabled advisor instances
+     */
+    List<Advisor> getEnabledAdvisors(CoreSettings settings);
+}

--- a/src/main/java/com/moguyn/deepdesk/advisor/DefaultAdvisorService.java
+++ b/src/main/java/com/moguyn/deepdesk/advisor/DefaultAdvisorService.java
@@ -1,0 +1,42 @@
+package com.moguyn.deepdesk.advisor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.ai.chat.client.advisor.api.Advisor;
+import org.springframework.stereotype.Service;
+
+import com.moguyn.deepdesk.config.CoreSettings;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Default implementation of AdvisorService that configures advisors based on
+ * application settings.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DefaultAdvisorService implements AdvisorService {
+
+    private final ChatMemoryAdvisor chatMemoryAdvisor;
+
+    @Override
+    public List<Advisor> getEnabledAdvisors(CoreSettings settings) {
+        List<Advisor> enabledAdvisors = new ArrayList<>();
+
+        CoreSettings.Advisors advisorSettings = settings.advisors();
+        if (advisorSettings != null) {
+            if (advisorSettings.isChatMemoryAdvisorEnabled()) {
+                log.info("Enabling Chat Memory Advisor");
+                enabledAdvisors.add(chatMemoryAdvisor);
+            }
+        } else {
+            log.warn("No advisor configuration found, enabling all advisors by default");
+            enabledAdvisors.add(chatMemoryAdvisor);
+        }
+
+        return enabledAdvisors;
+    }
+}

--- a/src/main/java/com/moguyn/deepdesk/tools/DateTimeTools.java
+++ b/src/main/java/com/moguyn/deepdesk/tools/DateTimeTools.java
@@ -1,0 +1,26 @@
+package com.moguyn.deepdesk.tools;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+public class DateTimeTools {
+
+    @Tool(description = "Get the current date and time")
+    public String getCurrentDateTime() {
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return now.format(formatter);
+    }
+
+    @Tool(description = "Translate a Unix timestamp to a date and time")
+    public String translateUnixTimestamp(@ToolParam(description = "The Unix timestamp to translate") String timestamp) {
+        long unixTimestamp = Long.parseLong(timestamp);
+        LocalDateTime dateTime = LocalDateTime.ofEpochSecond(unixTimestamp, 0, ZoneOffset.UTC);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return dateTime.format(formatter);
+    }
+}

--- a/src/main/resources/mcp-servers.json
+++ b/src/main/resources/mcp-servers.json
@@ -4,12 +4,6 @@
             "command": "/Users/verrerie/git/deepdesk/.vscode/mcp-search-server",
             "args": []
         },
-        "time": {
-            "command": "uvx",
-            "args": [
-                "mcp-server-time"
-            ]
-        },
         "mysql": {
             "command": "npx",
             "args": [

--- a/src/test/java/com/moguyn/deepdesk/advisor/DefaultAdvisorServiceTest.java
+++ b/src/test/java/com/moguyn/deepdesk/advisor/DefaultAdvisorServiceTest.java
@@ -1,0 +1,84 @@
+package com.moguyn.deepdesk.advisor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import org.springframework.ai.chat.client.advisor.api.Advisor;
+
+import com.moguyn.deepdesk.config.CoreSettings;
+import com.moguyn.deepdesk.config.CoreSettings.Advisors;
+import com.moguyn.deepdesk.config.CoreSettings.LLM;
+import com.moguyn.deepdesk.config.CoreSettings.Prompt;
+import com.moguyn.deepdesk.config.CoreSettings.UI;
+
+class DefaultAdvisorServiceTest {
+
+    private DefaultAdvisorService advisorService;
+    private ChatMemoryAdvisor mockChatMemoryAdvisor;
+
+    @BeforeEach
+    public void setUp() {
+        mockChatMemoryAdvisor = mock(ChatMemoryAdvisor.class);
+        advisorService = new DefaultAdvisorService(mockChatMemoryAdvisor);
+    }
+
+    @Test
+    void shouldEnableChatMemoryAdvisorWhenConfigured() {
+        // Arrange
+        CoreSettings settings = new CoreSettings(
+                List.of(),
+                new UI(""),
+                new LLM(new Prompt(""), 1000, 1000),
+                new Advisors(true)
+        );
+
+        // Act
+        List<Advisor> enabledAdvisors = advisorService.getEnabledAdvisors(settings);
+
+        // Assert
+        assertEquals(1, enabledAdvisors.size());
+        assertTrue(enabledAdvisors.contains(mockChatMemoryAdvisor),
+                "ChatMemoryAdvisor should be enabled when configured");
+    }
+
+    @Test
+    void shouldNotEnableChatMemoryAdvisorWhenDisabled() {
+        // Arrange
+        CoreSettings settings = new CoreSettings(
+                List.of(),
+                new UI(""),
+                new LLM(new Prompt(""), 1000, 1000),
+                new Advisors(false)
+        );
+
+        // Act
+        List<Advisor> enabledAdvisors = advisorService.getEnabledAdvisors(settings);
+
+        // Assert
+        assertTrue(enabledAdvisors.isEmpty(),
+                "No advisors should be enabled when configured to be disabled");
+    }
+
+    @Test
+    void shouldEnableAllAdvisorsWhenNoAdvisorSettings() {
+        // Arrange
+        CoreSettings settings = new CoreSettings(
+                List.of(),
+                new UI(""),
+                new LLM(new Prompt(""), 1000, 1000),
+                null
+        );
+
+        // Act
+        List<Advisor> enabledAdvisors = advisorService.getEnabledAdvisors(settings);
+
+        // Assert
+        assertEquals(1, enabledAdvisors.size());
+        assertTrue(enabledAdvisors.contains(mockChatMemoryAdvisor),
+                "ChatMemoryAdvisor should be enabled when no advisor settings provided");
+    }
+}

--- a/src/test/java/com/moguyn/deepdesk/config/ApplicationConfigChatClientTest.java
+++ b/src/test/java/com/moguyn/deepdesk/config/ApplicationConfigChatClientTest.java
@@ -1,5 +1,6 @@
 package com.moguyn.deepdesk.config;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -17,13 +18,13 @@ import com.moguyn.deepdesk.config.CoreSettings.Prompt;
 import com.moguyn.deepdesk.config.CoreSettings.UI;
 
 /**
- * Tests for the advisor configuration in ApplicationConfig. These tests
- * complement the more focused AdvisorService tests.
+ * Tests for the ChatClient creation in ApplicationConfig, using a mocked
+ * AdvisorService.
  */
-public class AdvisorConfigTest {
+class ApplicationConfigChatClientTest {
 
     @Test
-    public void testAllAdvisorsEnabled() {
+    void shouldCreateChatClientWithAdvisors() {
         // Arrange
         ApplicationConfig config = new ApplicationConfig();
 
@@ -32,27 +33,26 @@ public class AdvisorConfigTest {
         ToolCallbackProvider toolCallbackProvider = mock(ToolCallbackProvider.class);
         AdvisorService advisorService = mock(AdvisorService.class);
         ChatClient chatClient = mock(ChatClient.class);
-        Advisor mockAdvisor = mock(Advisor.class);
 
-        // Setup CoreSettings with all advisors enabled
-        CoreSettings coreSettings = new CoreSettings(
-                List.of(),
-                new UI(""),
-                new LLM(new Prompt(""),
-                        1000,
-                        1000
-                ),
-                new CoreSettings.Advisors(true));
-
-        // Setup mocked chain
+        // Configure mocks
         when(chatClientBuilder.defaultSystem(any(String.class))).thenReturn(chatClientBuilder);
         when(chatClientBuilder.defaultTools(any(ToolCallbackProvider.class))).thenReturn(chatClientBuilder);
         when(chatClientBuilder.defaultTools(any(Class.class))).thenReturn(chatClientBuilder);
         when(chatClientBuilder.defaultAdvisors(any(Advisor[].class))).thenReturn(chatClientBuilder);
         when(chatClientBuilder.build()).thenReturn(chatClient);
 
-        // Mock the advisor service to return an advisor
-        when(advisorService.getEnabledAdvisors(any(CoreSettings.class))).thenReturn(List.of(mockAdvisor));
+        // Setup core settings
+        CoreSettings coreSettings = new CoreSettings(
+                List.of(),
+                new UI(""),
+                new LLM(new Prompt(""), 1000, 1000),
+                new CoreSettings.Advisors(true)
+        );
+
+        // Mock advisor service to return one advisor
+        List<Advisor> mockAdvisors = new ArrayList<>();
+        mockAdvisors.add(mock(Advisor.class));
+        when(advisorService.getEnabledAdvisors(any(CoreSettings.class))).thenReturn(mockAdvisors);
 
         // Act
         ChatClient result = config.chatClient(
@@ -68,7 +68,7 @@ public class AdvisorConfigTest {
     }
 
     @Test
-    public void testSomeAdvisorsDisabled() {
+    void shouldCreateChatClientWithoutAdvisors() {
         // Arrange
         ApplicationConfig config = new ApplicationConfig();
 
@@ -78,23 +78,21 @@ public class AdvisorConfigTest {
         AdvisorService advisorService = mock(AdvisorService.class);
         ChatClient chatClient = mock(ChatClient.class);
 
-        // Setup CoreSettings with some advisors disabled
-        CoreSettings coreSettings = new CoreSettings(
-                List.of(),
-                new UI(""),
-                new LLM(new Prompt(""),
-                        1000,
-                        1000
-                ),
-                new CoreSettings.Advisors(false));
-
-        // Setup mocked chain
+        // Configure mocks
         when(chatClientBuilder.defaultSystem(any(String.class))).thenReturn(chatClientBuilder);
         when(chatClientBuilder.defaultTools(any(ToolCallbackProvider.class))).thenReturn(chatClientBuilder);
         when(chatClientBuilder.defaultTools(any(Class.class))).thenReturn(chatClientBuilder);
         when(chatClientBuilder.build()).thenReturn(chatClient);
 
-        // Mock the advisor service to return an empty list
+        // Setup core settings
+        CoreSettings coreSettings = new CoreSettings(
+                List.of(),
+                new UI(""),
+                new LLM(new Prompt(""), 1000, 1000),
+                new CoreSettings.Advisors(false)
+        );
+
+        // Mock advisor service to return empty list
         when(advisorService.getEnabledAdvisors(any(CoreSettings.class))).thenReturn(List.of());
 
         // Act

--- a/src/test/java/com/moguyn/deepdesk/tools/DateTimeToolsTest.java
+++ b/src/test/java/com/moguyn/deepdesk/tools/DateTimeToolsTest.java
@@ -1,0 +1,74 @@
+package com.moguyn.deepdesk.tools;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link DateTimeTools} class.
+ */
+class DateTimeToolsTest {
+
+    private DateTimeTools dateTimeTools;
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    @BeforeEach
+    public void setUp() {
+        dateTimeTools = new DateTimeTools();
+    }
+
+    @Test
+    void getCurrentDateTime_shouldReturnCurrentDateTimeInCorrectFormat() {
+        // When
+        String result = dateTimeTools.getCurrentDateTime();
+
+        // Then
+        // Verify the format is correct (yyyy-MM-dd HH:mm:ss)
+        assertTrue(result.matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"),
+                "Date format should match 'yyyy-MM-dd HH:mm:ss'");
+
+        // Verify the date is close to now
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime resultDateTime = LocalDateTime.parse(result, FORMATTER);
+
+        long diffInSeconds = Math.abs(
+                now.toEpochSecond(ZoneOffset.UTC) - resultDateTime.toEpochSecond(ZoneOffset.UTC));
+
+        // The result should be within 5 seconds of the current time
+        assertTrue(diffInSeconds < 5, "Date should be close to current time");
+    }
+
+    @Test
+    void translateUnixTimestamp_shouldCorrectlyFormatTimestamp() {
+        // Given
+        String unixTimestamp = "1609459200"; // 2021-01-01 00:00:00 UTC
+        String expected = "2021-01-01 00:00:00";
+
+        // When
+        String result = dateTimeTools.translateUnixTimestamp(unixTimestamp);
+
+        // Then
+        assertEquals(expected, result, "Unix timestamp should be correctly translated");
+    }
+
+    @Test
+    void translateUnixTimestamp_shouldHandleRecentTimestamp() {
+        // Given
+        long currentUnixTime = System.currentTimeMillis() / 1000;
+        String unixTimestamp = String.valueOf(currentUnixTime);
+
+        // When
+        String result = dateTimeTools.translateUnixTimestamp(unixTimestamp);
+
+        // Then
+        LocalDateTime expectedDateTime = LocalDateTime.ofEpochSecond(currentUnixTime, 0, ZoneOffset.UTC);
+        String expected = expectedDateTime.format(FORMATTER);
+
+        assertEquals(expected, result, "Recent unix timestamp should be correctly translated");
+    }
+}


### PR DESCRIPTION
## Overview
This PR applies SOLID principles to improve the advisor configuration in the application by extracting it to a dedicated service layer.

## What Changed
- Created `AdvisorService` interface for better abstraction
- Implemented `DefaultAdvisorService` with responsibility for advisor configuration
- Updated `ApplicationConfig` to use service instead of direct configuration
- Added comprehensive test suite for each component
- Decoupled `AdvisorConfigTest` from implementation details
- Added tests for `DateTimeTools`

## Why
- The previous implementation had the advisor configuration logic embedded in ApplicationConfig
- Test for AdvisorConfig was tightly coupled to implementation details of both ApplicationConfig and DateTimeTools
- This change makes the code more modular and ensures test independence
- Better separation of concerns and improved maintainability

## Testing
All tests pass, including the new tests for the refactored components.
```
Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
```