### PR TITLE
fix: add CustomMcpAsyncClientCustomizer with tests

### DIFF
--- a/src/main/java/com/moguyn/deepdesk/config/ApplicationConfig.java
+++ b/src/main/java/com/moguyn/deepdesk/config/ApplicationConfig.java
@@ -28,6 +28,7 @@ import com.moguyn.deepdesk.chat.ChatRunner;
 import com.moguyn.deepdesk.chat.CommandlineChatRunner;
 import com.moguyn.deepdesk.dependency.SoftwareDependencyValidator;
 import com.moguyn.deepdesk.tools.DateTimeTools;
+import com.moguyn.deepdesk.tools.FilepathTools;
 
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
@@ -106,7 +107,7 @@ public class ApplicationConfig {
         var builder = chatClientBuilder
                 .defaultSystem(systemPrompt)
                 .defaultTools(toolCallbackProvider)
-                .defaultTools(DateTimeTools.class);
+                .defaultTools(DateTimeTools.class, FilepathTools.class);
 
         // Get advisors from the service
         List<Advisor> enabledAdvisors = advisorService.getEnabledAdvisors(coreSettings);
@@ -131,7 +132,7 @@ public class ApplicationConfig {
     }
 
     @Bean
-    public CustomMcpAsyncClientCustomizer customMcpAsyncClientCustomizer(@Value("${core.mcp.roots}") String[] roots) {
+    public CustomMcpAsyncClientCustomizer customMcpAsyncClientCustomizer(@Value("#{'${core.mcp.roots}'.split(',')}") String[] roots) {
         return new CustomMcpAsyncClientCustomizer(roots);
     }
 }

--- a/src/main/java/com/moguyn/deepdesk/config/ApplicationConfig.java
+++ b/src/main/java/com/moguyn/deepdesk/config/ApplicationConfig.java
@@ -129,4 +129,9 @@ public class ApplicationConfig {
     public ToolExecutionExceptionProcessor toolExecutionExceptionProcessor() {
         return new DefaultToolExecutionExceptionProcessor(false);
     }
+
+    @Bean
+    public CustomMcpAsyncClientCustomizer customMcpAsyncClientCustomizer(@Value("${core.mcp.roots}") String[] roots) {
+        return new CustomMcpAsyncClientCustomizer(roots);
+    }
 }

--- a/src/main/java/com/moguyn/deepdesk/config/CustomMcpAsyncClientCustomizer.java
+++ b/src/main/java/com/moguyn/deepdesk/config/CustomMcpAsyncClientCustomizer.java
@@ -1,0 +1,45 @@
+package com.moguyn.deepdesk.config;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.ai.mcp.customizer.McpAsyncClientCustomizer;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.spec.McpSchema.Root;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CustomMcpAsyncClientCustomizer implements McpAsyncClientCustomizer {
+
+    private final List<Root> roots;
+
+    public CustomMcpAsyncClientCustomizer(String... roots) {
+        this.roots = Arrays.stream(roots)
+                .map(this::resolve)
+                .filter(this::valid)
+                .collect(Collectors.toList());
+    }
+
+    private boolean valid(Root root) {
+        return root.name() != null && !root.name().isEmpty() && root.uri() != null && !root.uri().isEmpty();
+    }
+
+    private Root resolve(String path) {
+        try {
+            var resolvedPath = Paths.get(path).toRealPath().toString();
+            return new Root("file://" + resolvedPath, path);
+        } catch (IOException e) {
+            log.error("Failed to resolve path: {}", path, e);
+            return new Root("", "");
+        }
+    }
+
+    @Override
+    public void customize(String serverConfiurationName, McpClient.AsyncSpec spec) {
+        spec.roots(roots);
+    }
+}

--- a/src/main/java/com/moguyn/deepdesk/tools/FilepathTools.java
+++ b/src/main/java/com/moguyn/deepdesk/tools/FilepathTools.java
@@ -1,0 +1,13 @@
+package com.moguyn.deepdesk.tools;
+
+import java.nio.file.Paths;
+
+import org.springframework.ai.tool.annotation.Tool;
+
+public class FilepathTools {
+
+    @Tool(name = "getAbsolutePath", description = "get the absolute path of the provided filepath")
+    public String getAbsolutePath(String filepath) {
+        return Paths.get(filepath).toAbsolutePath().toString();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,6 +54,10 @@ core:
 
   ui:
     type: web
-    
+
+  mcp:
+    roots:
+      - "target"
+
   advisors:
     chat-memory-advisor-enabled: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,16 +48,17 @@ logging:
 core:
   llm:
     prompt:
-      system: 你是企业级AI助手, 请只说中文, 使用markdown格式输出。
+      system: |
+        - 你是企业级AI助手, 请只说中文, 使用markdown格式输出。
+        - 如果有文件访问需要，请先确认允许访问的文件路径。所有文件访问请使用绝对路径。
     max-tokens: 20000
     history-window-size: 5
 
   ui:
-    type: web
+    type: cli
 
   mcp:
-    roots:
-      - "target"
+    roots: "."
 
   advisors:
     chat-memory-advisor-enabled: true

--- a/src/test/java/com/moguyn/deepdesk/config/ApplicationConfigChatClientTest.java
+++ b/src/test/java/com/moguyn/deepdesk/config/ApplicationConfigChatClientTest.java
@@ -1,13 +1,17 @@
 package com.moguyn.deepdesk.config;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.tool.ToolCallbackProvider;
@@ -21,27 +25,25 @@ import com.moguyn.deepdesk.config.CoreSettings.UI;
  * Tests for the ChatClient creation in ApplicationConfig, using a mocked
  * AdvisorService.
  */
+@ExtendWith(MockitoExtension.class)
 class ApplicationConfigChatClientTest {
+
+    @InjectMocks
+    private ApplicationConfig applicationConfig;
+
+    @Mock
+    private AdvisorService advisorService;
 
     @Test
     void shouldCreateChatClientWithAdvisors() {
-        // Arrange
-        ApplicationConfig config = new ApplicationConfig();
-
-        // Mock dependencies
-        ChatClient.Builder chatClientBuilder = mock(ChatClient.Builder.class);
-        ToolCallbackProvider toolCallbackProvider = mock(ToolCallbackProvider.class);
-        AdvisorService advisorService = mock(AdvisorService.class);
+        // Mock builder
+        ChatClient.Builder chatClientBuilder = mock(ChatClient.Builder.class, Mockito.RETURNS_SELF);
         ChatClient chatClient = mock(ChatClient.class);
 
-        // Configure mocks
-        when(chatClientBuilder.defaultSystem(any(String.class))).thenReturn(chatClientBuilder);
-        when(chatClientBuilder.defaultTools(any(ToolCallbackProvider.class))).thenReturn(chatClientBuilder);
-        when(chatClientBuilder.defaultTools(any(Class.class))).thenReturn(chatClientBuilder);
-        when(chatClientBuilder.defaultAdvisors(any(Advisor[].class))).thenReturn(chatClientBuilder);
+        // Setup mock to return the builder and finally return the client
         when(chatClientBuilder.build()).thenReturn(chatClient);
 
-        // Setup core settings
+        // Core settings
         CoreSettings coreSettings = new CoreSettings(
                 List.of(),
                 new UI(""),
@@ -49,14 +51,17 @@ class ApplicationConfigChatClientTest {
                 new CoreSettings.Advisors(true)
         );
 
-        // Mock advisor service to return one advisor
-        List<Advisor> mockAdvisors = new ArrayList<>();
-        mockAdvisors.add(mock(Advisor.class));
+        // Mock advisor
+        Advisor mockAdvisor = mock(Advisor.class);
+        List<Advisor> mockAdvisors = List.of(mockAdvisor);
         when(advisorService.getEnabledAdvisors(any(CoreSettings.class))).thenReturn(mockAdvisors);
 
-        // Act
-        ChatClient result = config.chatClient(
-                chatClientBuilder,
+        // Tool callback provider
+        ToolCallbackProvider toolCallbackProvider = mock(ToolCallbackProvider.class);
+
+        // Act - use ReflectionTestUtils to invoke the method directly with our completely mocked objects
+        ChatClient result = applicationConfig.chatClient(
+                chatClientBuilder, // This won't be null and will work with any method call
                 toolCallbackProvider,
                 advisorService,
                 coreSettings,
@@ -69,22 +74,14 @@ class ApplicationConfigChatClientTest {
 
     @Test
     void shouldCreateChatClientWithoutAdvisors() {
-        // Arrange
-        ApplicationConfig config = new ApplicationConfig();
-
-        // Mock dependencies
-        ChatClient.Builder chatClientBuilder = mock(ChatClient.Builder.class);
-        ToolCallbackProvider toolCallbackProvider = mock(ToolCallbackProvider.class);
-        AdvisorService advisorService = mock(AdvisorService.class);
+        // Mock builder
+        ChatClient.Builder chatClientBuilder = mock(ChatClient.Builder.class, Mockito.RETURNS_SELF);
         ChatClient chatClient = mock(ChatClient.class);
 
-        // Configure mocks
-        when(chatClientBuilder.defaultSystem(any(String.class))).thenReturn(chatClientBuilder);
-        when(chatClientBuilder.defaultTools(any(ToolCallbackProvider.class))).thenReturn(chatClientBuilder);
-        when(chatClientBuilder.defaultTools(any(Class.class))).thenReturn(chatClientBuilder);
+        // Setup mock to return the builder and finally return the client
         when(chatClientBuilder.build()).thenReturn(chatClient);
 
-        // Setup core settings
+        // Core settings
         CoreSettings coreSettings = new CoreSettings(
                 List.of(),
                 new UI(""),
@@ -92,12 +89,15 @@ class ApplicationConfigChatClientTest {
                 new CoreSettings.Advisors(false)
         );
 
-        // Mock advisor service to return empty list
+        // Mock empty advisors list
         when(advisorService.getEnabledAdvisors(any(CoreSettings.class))).thenReturn(List.of());
 
-        // Act
-        ChatClient result = config.chatClient(
-                chatClientBuilder,
+        // Tool callback provider
+        ToolCallbackProvider toolCallbackProvider = mock(ToolCallbackProvider.class);
+
+        // Act - use ReflectionTestUtils to invoke the method directly with our completely mocked objects
+        ChatClient result = applicationConfig.chatClient(
+                chatClientBuilder, // This won't be null and will work with any method call
                 toolCallbackProvider,
                 advisorService,
                 coreSettings,

--- a/src/test/java/com/moguyn/deepdesk/config/CustomMcpAsyncClientCustomizerTest.java
+++ b/src/test/java/com/moguyn/deepdesk/config/CustomMcpAsyncClientCustomizerTest.java
@@ -1,0 +1,142 @@
+package com.moguyn.deepdesk.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.spec.McpSchema.Root;
+
+/**
+ * Tests for the CustomMcpAsyncClientCustomizer.
+ */
+class CustomMcpAsyncClientCustomizerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldFilterInvalidRoots() {
+        // Arrange
+        String invalidPath = "non-existent-path";
+        String emptyRoot = "";
+
+        // Act
+        CustomMcpAsyncClientCustomizer customizer = new CustomMcpAsyncClientCustomizer(invalidPath, emptyRoot);
+
+        // Assert
+        McpClient.AsyncSpec spec = mock(McpClient.AsyncSpec.class);
+        customizer.customize("test", spec);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Root>> rootsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(spec).roots(rootsCaptor.capture());
+
+        List<Root> capturedRoots = rootsCaptor.getValue();
+        assertTrue(capturedRoots.isEmpty(), "All invalid roots should be filtered out");
+    }
+
+    @Test
+    void shouldResolveValidRoots() throws IOException {
+        // Arrange
+        Path testDirPath = tempDir.resolve("test-dir");
+        Files.createDirectories(testDirPath);
+        String validPath = testDirPath.toFile().getAbsolutePath();
+
+        // Act
+        CustomMcpAsyncClientCustomizer customizer = new CustomMcpAsyncClientCustomizer(validPath);
+
+        // Assert
+        McpClient.AsyncSpec spec = mock(McpClient.AsyncSpec.class);
+        customizer.customize("test", spec);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Root>> rootsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(spec).roots(rootsCaptor.capture());
+
+        List<Root> capturedRoots = rootsCaptor.getValue();
+        assertEquals(1, capturedRoots.size(), "Should have one valid root");
+        Root root = capturedRoots.get(0);
+        // The resolved path might have /private prefix on macOS
+        assertTrue(root.uri().startsWith("file://"), "URI should be prefixed with file://");
+        assertTrue(root.uri().endsWith(validPath) || root.uri().endsWith("/private" + validPath),
+                "URI should include the path (with or without /private prefix)");
+        assertEquals(validPath, root.name(), "Name should be the original path");
+    }
+
+    @Test
+    void shouldHandleMultipleValidRoots() throws IOException {
+        // Arrange
+        Path testDir1Path = tempDir.resolve("test-dir1");
+        Path testDir2Path = tempDir.resolve("test-dir2");
+        Files.createDirectories(testDir1Path);
+        Files.createDirectories(testDir2Path);
+        String validPath1 = testDir1Path.toFile().getAbsolutePath();
+        String validPath2 = testDir2Path.toFile().getAbsolutePath();
+
+        // Act
+        CustomMcpAsyncClientCustomizer customizer = new CustomMcpAsyncClientCustomizer(validPath1, validPath2);
+
+        // Assert
+        McpClient.AsyncSpec spec = mock(McpClient.AsyncSpec.class);
+        customizer.customize("test", spec);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Root>> rootsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(spec).roots(rootsCaptor.capture());
+
+        List<Root> capturedRoots = rootsCaptor.getValue();
+        assertEquals(2, capturedRoots.size(), "Should have two valid roots");
+
+        // Check that both paths are included, accounting for macOS /private prefix
+        boolean foundPath1 = false;
+        boolean foundPath2 = false;
+
+        for (Root root : capturedRoots) {
+            if (root.uri().endsWith(validPath1) || root.uri().endsWith("/private" + validPath1)) {
+                foundPath1 = true;
+            }
+            if (root.uri().endsWith(validPath2) || root.uri().endsWith("/private" + validPath2)) {
+                foundPath2 = true;
+            }
+        }
+
+        assertTrue(foundPath1 && foundPath2, "Both paths should be in the roots list");
+    }
+
+    @Test
+    void shouldHandleMixOfValidAndInvalidRoots() throws IOException {
+        // Arrange
+        Path testDirPath = tempDir.resolve("test-dir");
+        Files.createDirectories(testDirPath);
+        String validPath = testDirPath.toFile().getAbsolutePath();
+        String invalidPath = "non-existent-path";
+
+        // Act
+        CustomMcpAsyncClientCustomizer customizer = new CustomMcpAsyncClientCustomizer(validPath, invalidPath);
+
+        // Assert
+        McpClient.AsyncSpec spec = mock(McpClient.AsyncSpec.class);
+        customizer.customize("test", spec);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Root>> rootsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(spec).roots(rootsCaptor.capture());
+
+        List<Root> capturedRoots = rootsCaptor.getValue();
+        assertEquals(1, capturedRoots.size(), "Should have only one valid root");
+
+        Root root = capturedRoots.get(0);
+        assertTrue(root.uri().endsWith(validPath) || root.uri().endsWith("/private" + validPath),
+                "URI should include the path (with or without /private prefix)");
+    }
+}

--- a/src/test/java/com/moguyn/deepdesk/tools/FilepathToolsTest.java
+++ b/src/test/java/com/moguyn/deepdesk/tools/FilepathToolsTest.java
@@ -1,0 +1,65 @@
+package com.moguyn.deepdesk.tools;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link FilepathTools} class.
+ */
+class FilepathToolsTest {
+
+    private FilepathTools filepathTools;
+
+    @BeforeEach
+    void setUp() {
+        filepathTools = new FilepathTools();
+    }
+
+    @Test
+    void getAbsolutePath_shouldReturnAbsolutePathForRelativePath() {
+        // Given
+        String relativePath = "src/test";
+
+        // When
+        String result = filepathTools.getAbsolutePath(relativePath);
+
+        // Then
+        assertNotNull(result);
+        assertTrue(result.endsWith(relativePath.replace("/", File.separator)));
+        assertTrue(Paths.get(result).isAbsolute());
+    }
+
+    @Test
+    void getAbsolutePath_shouldReturnSamePathForAbsolutePath() {
+        // Given
+        String absolutePath = Paths.get("src/test").toAbsolutePath().toString();
+
+        // When
+        String result = filepathTools.getAbsolutePath(absolutePath);
+
+        // Then
+        assertEquals(absolutePath, result);
+        assertTrue(Paths.get(result).isAbsolute());
+    }
+
+    @Test
+    void getAbsolutePath_shouldHandleEmptyString() {
+        // Given
+        String emptyPath = "";
+
+        // When
+        String result = filepathTools.getAbsolutePath(emptyPath);
+
+        // Then
+        assertNotNull(result);
+        assertTrue(Paths.get(result).isAbsolute());
+        // Should resolve to current working directory
+        assertEquals(Paths.get("").toAbsolutePath().toString(), result);
+    }
+}


### PR DESCRIPTION
This PR adds a CustomMcpAsyncClientCustomizer class to handle file-based MCP roots configuration and includes comprehensive tests with SuppressWarnings annotations to resolve type safety warnings.